### PR TITLE
Setlevel

### DIFF
--- a/EpiLog/__init__.py
+++ b/EpiLog/__init__.py
@@ -2,4 +2,4 @@
     EpiLog
 
 """
-__version__ = "0.1.0"
+__version__ = "1.0.0"

--- a/EpiLog/manager.py
+++ b/EpiLog/manager.py
@@ -126,6 +126,8 @@ class EpiLog:
 
         if hasattr(self, "_stream"):
             previous = self._stream
+            value.setFormatter(self.formatter)
+            value.setLevel(self.level)
             self._stream = value
             for log in self.loggers.values():
                 log.removeHandler(previous)

--- a/EpiLog/manager.py
+++ b/EpiLog/manager.py
@@ -107,7 +107,6 @@ class EpiLog:
         self._formatter = value
         self.stream.setFormatter(self.formatter)
         for log in self.loggers.values():
-            log.setFormatter(self.formatter)
             for handle in log.handlers:
                 handle.setFormatter(self.formatter)
 

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -51,7 +51,7 @@ def test_level_change():
     manager = EpiLog(level=logging.INFO, stream=handler)
     log = manager.get_logger("test")
 
-    message = "You are blind to reality and for that I am most proud"
+    message = "I would say that he's blessedly unburdened with the complications of a university education."
     log.debug(message)
     stream.seek(0)
     output = stream.read()

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -2,6 +2,7 @@
     EpiLog/tests/test_manager.py
 
 """
+import os
 import logging
 import pytest
 from io import StringIO
@@ -89,4 +90,10 @@ def test_levels(level):
 ])
 def test_handlers(handler):
     manager = EpiLog(stream=handler)
+
+    # Cleanup by removing file created by file handler
+    if isinstance(handler, logging.FileHandler):
+        os.remove(handler.baseFilename)
+
     assert manager.stream == handler
+

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -69,6 +69,34 @@ def test_level_change():
     assert message in output, "Message not Found in output stream after logging"
 
 
+def test_format_change():
+    stream = StringIO()
+    handler = logging.StreamHandler(stream)
+    manager = EpiLog(level=logging.INFO, stream=handler)
+    log = manager.get_logger("test")
+
+    # Modify Formatter
+    manager.formatter = logging.Formatter("%(levelname)s | %(message)s")
+    message = "I have no idea why all of this is happening or how to control it."
+    log.info(message)
+
+    stream.seek(0)
+    output = stream.read()
+    stream.close()
+
+    assert f"INFO | {message}\n" == output
+
+
+@pytest.mark.parametrize("f", [
+    None,
+    pytest.param("Failure", marks=pytest.mark.xfail(raises=TypeError)),
+    logging.Formatter("%(name)s | %(levelname)s | %(message)s"),
+])
+def test_format(f):
+    manager = EpiLog(formatter=f)
+    manager.formatter = f
+
+
 @pytest.mark.parametrize("level", [
     logging.NOTSET,
     logging.DEBUG,

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -39,6 +39,31 @@ def test_stream():
 
     stream.seek(0)
     output = stream.read()
+    stream.close()
+
+    assert message in output, "Message not Found in output stream after logging"
+
+
+def test_level_change():
+    stream = StringIO()
+
+    handler = logging.StreamHandler(stream)
+    manager = EpiLog(level=logging.INFO, stream=handler)
+    log = manager.get_logger("test")
+
+    message = "You are blind to reality and for that I am most proud"
+    log.debug(message)
+    stream.seek(0)
+    output = stream.read()
+    assert message not in output, "Message should not have been Received"
+
+    # Then repeat after Changing level
+    manager.level = logging.DEBUG
+    log.debug(message)
+
+    stream.seek(0)
+    output = stream.read()
+    stream.close()
 
     assert message in output, "Message not Found in output stream after logging"
 

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -87,6 +87,40 @@ def test_format_change():
     assert f"INFO | {message}\n" == output
 
 
+def test_stream_change():
+    stream_a = StringIO()
+    stream_b = StringIO()
+    handler_a = logging.StreamHandler(stream_a)
+    handler_b = logging.StreamHandler(stream_b)
+
+    manager = EpiLog(
+        level=logging.INFO,
+        stream=handler_a,
+        formatter=logging.Formatter("%(levelname)s | %(message)s")
+    )
+    log = manager.get_logger("test")
+
+    # Modify Stream
+    manager.stream = handler_b
+    assert manager.stream == handler_b
+
+    message = "You humans have so many emotions! You only need two: anger and confusion!"
+    expected = f"INFO | {message}\n"
+    log.info(message)
+
+    # Test first stream
+    stream_a.seek(0)
+    output_a = stream_a.read()
+    stream_a.close()
+    assert output_a != expected
+
+    # Test Second, Expected stream
+    stream_b.seek(0)
+    output_b = stream_b.read()
+    stream_b.close()
+    assert output_b == expected
+
+
 @pytest.mark.parametrize("f", [
     None,
     pytest.param("Failure", marks=pytest.mark.xfail(raises=TypeError)),

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -96,4 +96,3 @@ def test_handlers(handler):
         os.remove(handler.baseFilename)
 
     assert manager.stream == handler
-


### PR DESCRIPTION
This fixes a bug, when users attempt to change the level (or formatter) of the EpiLog class instance, to reflect those modifications on the attached handler stream.