### PR TITLE
Cache get logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,60 @@
+<!-- omit in toc -->
 # EpiLog
 Simple Logging Manager
+
+<!-- omit in toc -->
+## Table of Contents
+- [Installation](#installation)
+- [Examples](#examples)
+- [License](#license)
+
+# Installation
+Install from [pypi](https://pypi.org/project/EpiLog/) using pip.
+
+```bash
+pip install EpiLog
+```
+
+or directly from github, if you want the latest dev
+
+```bash
+pip install git+https://github.com/Spill-Tea/EpiLog@main
+```
+
+# Examples
+
+Creating a logging manager and dispatch a logger.
+```python
+import logging
+from EpiLog import EpiLog
+
+formatter = logging.Formatter("%(asctime)s | %(levelname)s | %(message)s")
+manager: EpiLog = EpiLog(logging.DEBUG, formatter=formatter)
+log: logging.Logger = manager.get_logger(__name__)
+log.debug("We made a logger!")
+
+# And easily remove the logger
+manager.remove(log)
+assert __name__ not in manager
+```
+
+
+Benchmarking real time duration to accomplish a function,
+or sereis of tasks within a facile context manager.
+
+```python
+import logging
+from EpiLog import Benchmark
+
+message: str = "Long Task Complete"
+level: int = logging.INFO  # level to emit message
+with Benchmark(log, message, level):
+    perform_long_task(...)
+
+```
+Note, that if the level used to emit the message is below
+your logger level, then no message will be emitted.
+
+# License
+
+[MIT](LICENSE)

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ assert __name__ not in manager
 
 
 Benchmarking real time duration to accomplish a function,
-or sereis of tasks within a facile context manager.
+or a series of tasks within a facile context manager.
 
 ```python
 import logging

--- a/src/EpiLog/__init__.py
+++ b/src/EpiLog/__init__.py
@@ -25,4 +25,4 @@ from .benchmark import BenchMark
 from .manager import EpiLog
 
 
-__version__ = "1.1.1"
+__version__ = "1.1.2"

--- a/src/EpiLog/manager.py
+++ b/src/EpiLog/manager.py
@@ -195,6 +195,6 @@ class EpiLog:
         log: logging.Logger = logging.getLogger(name)
         log.setLevel(self.level)
         log.addHandler(self.stream)
-        self[name] = log
+        self.loggers[name] = log
 
         return log

--- a/src/EpiLog/manager.py
+++ b/src/EpiLog/manager.py
@@ -104,6 +104,9 @@ class EpiLog:
         """Retrieve Logger by name."""
         return self.loggers[item]
 
+    def __contains__(self, value: str) -> bool:
+        return value in self.loggers
+
     @property
     def level(self) -> int:
         """Logging Level."""
@@ -186,9 +189,12 @@ class EpiLog:
 
     def get_logger(self, name: str) -> logging.Logger:
         """Initialize a new logger."""
-        log = logging.getLogger(name)
+        if name in self:
+            return self[name]
+
+        log: logging.Logger = logging.getLogger(name)
         log.setLevel(self.level)
         log.addHandler(self.stream)
-        self.loggers[name] = log
+        self[name] = log
 
         return log

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -19,8 +19,19 @@ def test_get_logger(names, build_manager: Callable[..., EpiLog]) -> None:
 
     for n in names:
         manager.get_logger(n)
-    assert len(manager.loggers) == len(names)
+    assert len(manager.loggers) == len(set(names))
     assert all(i in manager.loggers for i in names)
+    assert all(j in manager for j in names)
+
+
+def test_get_logger_name_caches(build_manager: Callable[..., EpiLog]) -> None:
+    """Tests that we retrieve the same logger with the same name."""
+    manager: EpiLog = build_manager()
+    name: str = "doublethink"
+    loga: logging.Logger = manager.get_logger(name)
+    logb: logging.Logger = manager.get_logger(name)
+
+    assert id(loga) == id(logb), "Expected same object."
 
 
 def test_logging(build_manager: Callable[..., EpiLog]) -> None:


### PR DESCRIPTION
**_Preface_**

The `EpiLog.get_logger` function does not check the logger registry cache before dispatching a new logger. While the logging standard library does this internally and will return the correct logger, we would be adding the same handler (thus duplicating) again. This PR checks this cache before dispatch.

Also added a readme to the repository for better description.